### PR TITLE
Removed the (read str) from the valueAt function

### DIFF
--- a/libraries/haste-lib/src/Haste/Reactive/DOM.hs
+++ b/libraries/haste-lib/src/Haste/Reactive/DOM.hs
@@ -60,10 +60,7 @@ valueAt eid evt = filterMapS fromString $ unlessExists eid evt valueAtIO
   where
     valueAtIO = withElem eid $ \e -> do
       str <- getProp e "value"
-      (src, sig) <- case read str of
-        Just x -> pipe x
-        _      -> error $ "Bad initial value in valueAt: " ++ str
-  
+      (src, sig) <- pipe str
       success <- setCallback e evt $ constCallback $ do
         getProp e "value" >>= write src
 


### PR DESCRIPTION
Is this a typo? I wouldn't think that the value of input elements
would be Haskell data and not a string.

This was causing a browser error with the following:

```
sink writeLog $ valueOf eid
```
