### PR TITLE
Added a test-case for Data.IORef.atomicModifyIORef

### DIFF
--- a/Tests/IORef.hs
+++ b/Tests/IORef.hs
@@ -1,0 +1,9 @@
+module Tests.IORef where
+
+import Data.IORef
+
+runTest :: IO ()
+runTest = do
+    ref <- newIORef 23
+    atomicModifyIORef ref $ \ _ -> (42, ())
+    print =<< readIORef ref


### PR DESCRIPTION
This test-case fails on my machine.

```
$ ghc --version
The Glorious Glasgow Haskell Compilation System, version 7.6.3
$ hastec --version
0.2.4
```
