### PR TITLE
replace quotes globally.

### DIFF
--- a/lib/stdlib.js
+++ b/lib/stdlib.js
@@ -223,7 +223,7 @@ function jsCat(strs, sep) {
 
 // Escape all double quotes in a string
 function jsUnquote(str) {
-    return str.replace(/"/, '\\"');
+    return str.replace(/"/g, '\\"');
 }
 
 // Parse a JSON message into a Haste.JSON.JSON value.


### PR DESCRIPTION
Quoted strings are handled wrong. This fixes the issue.

> > > "asd \"is\" not \"asd\"".replace(/"/, '\"');
> > > "asd \"is" not "asd""
> > > "asd \"is\" not \"asd\"".replace(/"/g, '\"');
> > > "asd \"is\" not \"asd\""
