### PR TITLE
Get rid of runtime errors, return empty string if 'elem' has no 'prop' a...

### DIFF
--- a/lib/stdlib.js
+++ b/lib/stdlib.js
@@ -125,7 +125,11 @@ function jsSet(elem, prop, val) {
 }
 
 function jsGetAttr(elem, prop) {
-    return elem.getAttribute(prop).toString();
+    if(elem.hasAttribute(prop)) {
+        return elem.getAttribute(prop).toString();
+    } else {
+        return "";
+    }
 }
 
 function jsSetAttr(elem, prop, val) {


### PR DESCRIPTION
...ttribute.

fixes:  Haste.DOM.getAttr fails if the attribute is not set #140 
