### PR TITLE
Compiles with ghc7.8, passing 4/50 tests. Fixes #141, maybe.

### DIFF
--- a/src/Haste/CodeGen.hs
+++ b/src/Haste/CodeGen.hs
@@ -9,6 +9,9 @@ import Data.Word
 import Data.Char
 import Data.List (partition, foldl')
 import Data.Maybe (isJust)
+#if __GLASGOW_HASKELL__ >= 707
+import qualified Data.ByteString.Char8 as B
+#endif
 import qualified Data.Set as S
 import qualified Data.Map as M
 -- STG/GHC stuff
@@ -56,7 +59,7 @@ generate cfg fp pkgid modname binds =
     }
   where
     theMod = genAST cfg modname binds
-    
+
     insFun m (_, AST (Assign (NewVar _ (Internal v _)) body _) jumps) =
       M.insert v (AST body jumps) m
     insFun m _ =
@@ -194,7 +197,7 @@ genBindRec b =
 --   a recursive binding; this is because it's quite a lot easier to keep track
 --   of which functions depend on each other if every genBind call results in a
 --   single function being generated.
---   Use `genBindRec` to generate code for local potentially recursive bindings 
+--   Use `genBindRec` to generate code for local potentially recursive bindings
 --   as their dependencies get merged into their parent's anyway.
 genBind :: Bool -> Maybe Int -> StgBinding -> JSGen Config ()
 genBind onTopLevel funsInRecGroup (StgNonRec v rhs) = do
@@ -245,7 +248,7 @@ unRec b           = [(Nothing, b)]
 genArgVarsPair :: [(Var.Var, a)] -> JSGen Config ([J.Var], [a])
 genArgVarsPair vps = do
     vs' <- mapM genVar vs
-    return (vs', xs) 
+    return (vs', xs)
   where
     (vs, xs) = unzip $ filter (hasRepresentation . fst) vps
 
@@ -300,7 +303,7 @@ splitAlts :: [StgAlt] -> (StgAlt, [StgAlt])
 splitAlts alts =
     case partition isDefault alts of
       ([defAlt], otherAlts) -> (defAlt, otherAlts)
-      ([], otherAlts)       -> (last otherAlts, init otherAlts) 
+      ([], otherAlts)       -> (last otherAlts, init otherAlts)
       _                     -> error "More than one default alt in case!"
   where
     isDefault (DEFAULT, _, _, _) = True
@@ -456,7 +459,11 @@ dataConNameModule d =
 genLit :: L.Literal -> JSGen Config (AST Exp)
 genLit l = do
   case l of
+#if __GLASGOW_HASKELL__ >= 707
+    MachStr s           -> return . lit $ B.unpack s
+#else
     MachStr s           -> return . lit $ unpackFS s
+#endif
     MachInt n
       | n > 2147483647 ||
         n < -2147483648 -> do warn Verbose (constFail "Int" n)
@@ -501,7 +508,7 @@ genApp f xs = do
 
 -- | Does this data constructor create an enumeration type?
 isEnumerationDataCon :: DataCon -> Bool
-isEnumerationDataCon = isEnumerationTyCon . dataConTyCon    
+isEnumerationDataCon = isEnumerationTyCon . dataConTyCon
 
 -- | Returns True if the given Var is an unboxed tuple with a single element
 --   after any represenationless elements are discarded.

--- a/src/Haste/Util.hs
+++ b/src/Haste/Util.hs
@@ -4,10 +4,24 @@ module Haste.Util where
 import DynFlags
 import Outputable
 
-#if __GLASGOW_HASKELL__ >= 706
 showOutputable :: Outputable a => a -> String
+#if __GLASGOW_HASKELL__ >= 706
 showOutputable = showPpr tracingDynFlags
 #else
-showOutputable :: Outputable a => a -> String
 showOutputable = showPpr
+#endif
+
+#if __GLASGOW_HASKELL__ >= 707
+-- Taken from
+-- http://www.haskell.org/ghc/docs/7.6.3/html/libraries/ghc/src/DynFlags.html#tracingDynFlags
+--
+-- Do not use tracingDynFlags!
+-- tracingDynFlags is a hack, necessary because we need to be able to
+-- show SDocs when tracing, but we don't always have DynFlags available.
+-- Do not use it if you can help it. It will not reflect options set
+-- by the commandline flags, and all fields may be either wrong or
+-- undefined.
+tracingDynFlags :: DynFlags
+tracingDynFlags = defaultDynFlags tracingSettings
+    where tracingSettings = panic "Settings not defined in tracingDynFlags"
 #endif


### PR DESCRIPTION
Mac OS X 10.9.2, ghc 7.8.0.20140228, cabal-install 1.18.0.3, Cabal 1.18.1.3

Most tests fail, here is the output of ./runtests.sh: 
https://gist.github.com/schell/9945323

Also I'm using a cabal sandbox which may be affecting haste-boot but haste-boot is giving me this:

```
./.cabal-sandbox/bin/haste-boot
Downloading base libs from GitHub
Sending:
GET /haste-libs/haste-libs-0.2.99.tar.bz2 HTTP/1.1
Host: valderman.github.io


Creating new connection to valderman.github.io
Received:
HTTP/1.1 200 OK 
Server: GitHub.com
Content-Type: application/octet-stream
Last-Modified: Wed, 19 Mar 2014 19:05:37 GMT
Expires: Wed, 02 Apr 2014 18:04:42 GMT
Cache-Control: max-age=600
Content-Length: 1656645
Accept-Ranges: bytes
Date: Wed, 02 Apr 2014 23:26:35 GMT
Via: 1.1 varnish
Age: 19913
Connection: keep-alive
X-Served-By: cache-lax1420-LAX
X-Cache: HIT
X-Cache-Hits: 1
X-Timer: S1396481195.648370504,VS0,VE73
Vary: Accept-Encoding


Control/Shell.hs:(236,17)-(245,7): Missing field in record construction System.Process.Internals.delegate_ctlc
```
