### PR TITLE
Add the ability to pass flags to the Google Closure compiler

### DIFF
--- a/src/ArgSpecs.hs
+++ b/src/ArgSpecs.hs
@@ -39,6 +39,11 @@ argSpecs = [
               info = "Run the Google Closure compiler on the output. "
                    ++ "Use --opt-google-closure=foo.jar to hint that foo.jar "
                    ++ "is the Closure compiler."},
+    ArgSpec { optName = "opt-google-closure-flag=",
+              updateCfg = updateClosureFlags,
+              info = "Add an extra flag for the Google Closure compiler to take. "
+                   ++ "Use --opt-google-closure-flag='--language_in=ECMASCRIPT5_STRICT', "
+                   ++ "to optimize programs to strict mode"},
     ArgSpec { optName = "opt-sloppy-tce",
               updateCfg = useSloppyTCE,
               info = "Allow the possibility that some tail recursion may not "
@@ -130,6 +135,11 @@ updateClosureCfg cfg ['=':arg] =
   cfg {useGoogleClosure = Just arg}
 updateClosureCfg cfg _ =
   cfg {useGoogleClosure = Just closureCompiler}
+
+-- | Add flags for Google Closure to use
+updateClosureFlags :: Config -> [String] -> Config
+updateClosureFlags cfg args = cfg {
+  useGoogleClosureFlags = useGoogleClosureFlags cfg ++ args}
 
 -- | Enable optimizations over the entire program.
 enableWholeProgramOpts :: Config -> [String] -> Config

--- a/src/Haste/Config.hs
+++ b/src/Haste/Config.hs
@@ -93,6 +93,8 @@ data Config = Config {
     tracePrimops :: Bool,
     -- | Run the entire thing through Google Closure when done?
     useGoogleClosure :: Maybe FilePath,
+    -- | Extra flags for Google Closure to take?
+    useGoogleClosureFlags :: [String],
     -- | Any external Javascript to link into the JS bundle.
     jsExternals :: [FilePath]
   }
@@ -115,5 +117,6 @@ defConfig = Config {
     sloppyTCE        = False,
     tracePrimops     = False,
     useGoogleClosure = Nothing,
+    useGoogleClosureFlags = [],
     jsExternals      = []
   }

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -154,7 +154,9 @@ compiler cmdargs = do
 #endif
             link cfg pkgid file
             case useGoogleClosure cfg of
-              Just clopath -> closurize clopath $ outFile cfg file
+              Just clopath -> closurize clopath
+                                        (outFile cfg file)
+                                        (useGoogleClosureFlags cfg)
               _            -> return ()
 
 -- | Do everything required to get a list of STG bindings out of a module.
@@ -188,14 +190,16 @@ prepare dynflags theMod = do
 
 
 -- | Run Google Closure on a file.
-closurize :: FilePath -> FilePath -> IO ()
-closurize cloPath file = do
+closurize :: FilePath -> FilePath -> [String] -> IO ()
+closurize cloPath file arguments = do
   logStr $ "Running the Google Closure compiler on " ++ file ++ "..."
   let cloFile = file `addExtension` ".clo"
   cloOut <- openFile cloFile WriteMode
   build <- runProcess "java"
-             ["-jar", cloPath, "--compilation_level", "ADVANCED_OPTIMIZATIONS",
+             (["-jar", cloPath,
+              "--compilation_level", "ADVANCED_OPTIMIZATIONS",
               "--jscomp_off", "globalThis", file]
+              ++ arguments)
              Nothing
              Nothing
              Nothing


### PR DESCRIPTION
Fixes #153. I want this so that I can pass the `--language_in=ECMASCRIPT5_STRICT` flag to the Google Closure compiler.
