### PR TITLE
Bumping shellmate to 0.1.4.

### DIFF
--- a/haste-compiler.cabal
+++ b/haste-compiler.cabal
@@ -78,7 +78,7 @@ Executable haste-boot
         network,
         HTTP,
         executable-path,
-        shellmate >= 0.1.3
+        shellmate >= 0.1.4
     Default-Language: Haskell98
 
 Executable hastec


### PR DESCRIPTION
This fixes #164 and #160 if shellmate is compiled from source or the latest
pull request gets pushed to hackage.

You should push the new version of shellmate to hackage before accepting this PR.
