### PR TITLE
Fix #159: Unsupported PrimOps: isFloatFinite, isDoubleFinite

### DIFF
--- a/lib/rts.js
+++ b/lib/rts.js
@@ -166,6 +166,14 @@ function decodeDouble(x) {
     return [0, sign, manHigh, manLow, exp];
 }
 
+function isFloatFinite(x) {
+    return isFinite(x);
+}
+
+function isDoubleFinite(x) {
+    return isFinite(x);
+}
+
 function err(str) {
     die(toJSStr(str));
 }


### PR DESCRIPTION
It turned out that `isFloatFinite` and `isDoubleFinite` are not PrimOps, but foreign function calls in `libraries/base/GHC/Float.lhs`.

I implemented the foreign functions in lib/rts.js.
