### PR TITLE
Only take the first record from ghc-pkg query in haste-copy-pkg. Fixes #179

### DIFF
--- a/src/haste-copy-pkg.hs
+++ b/src/haste-copy-pkg.hs
@@ -39,6 +39,7 @@ fixPaths pkgname pkgtext =
              . map fixPath
              . filter (not . ("haddock" `isPrefixOf`))
              . filter (not . ("hs-libraries:" `isPrefixOf`))
+             . takeWhile (not . isPrefixOf "---")
              $ lines pkgtext
     
     fixPath str


### PR DESCRIPTION
Bug 179 (in my case, at least) was caused by ghc-pkg describe describing all installed instances of a package. With this patch, we only take the first instance of the package. I don't know off the top of my head that the first one is always the one that cabal-install would default to use, but it is at least better than creating mangled package.conf files.
