### PR TITLE
Calculate offset against currentTarget instead of target

### DIFF
--- a/lib/stdlib.js
+++ b/lib/stdlib.js
@@ -54,8 +54,8 @@ function jsGetMouseCoords(e) {
 	posy = e.clientY + document.body.scrollTop
 	    + document.documentElement.scrollTop;
     }
-    return [posx - (e.target.offsetLeft || 0),
-	    posy - (e.target.offsetTop || 0)];
+    return [posx - (e.currentTarget.offsetLeft || 0),
+	    posy - (e.currentTarget.offsetTop || 0)];
 }
 
 function jsSetCB(elem, evt, cb) {


### PR DESCRIPTION
Not sure if it was intended to calculate offset against target vs the currentTarget, the actual element the listener was attached to. I think currentTarget is better as you can, say, attach a mouse move listener to the documentBody and get absolute coordinates, which doesn't work for just "target."
