### PR TITLE
Implement an interface for DOM querySelector API

### DIFF
--- a/lib/stdlib.js
+++ b/lib/stdlib.js
@@ -163,6 +163,23 @@ function jsFind(elem) {
     return [0];
 }
 
+function jsQuerySelector(elem, query) {
+  if (!elem || typeof elem.querySelector !== 'function') {
+    return [0];
+  }
+
+  var e = elem.querySelector(query);
+  return e ? [1, [0, e]] : [0];
+}
+
+function jsQuerySelectorAll(elem, query) {
+  if (!elem || typeof elem.querySelectorAll !== 'function') {
+    return [0];
+  }
+
+  return [1, elem.querySelectorAll(query)];
+}
+
 function jsCreateElem(tag) {
     return document.createElement(tag);
 }


### PR DESCRIPTION
The current interface for finding elements through jsFind is limited, in
that it only uses lookup by ID. Getting DOM elements through arbitrary
query selectors (primarily utilizing classes) is a popular way in the
JavaScript ecosystem, specially to get multiple similar elements (say
all the children `li` items of a `ul`: `ul#my-list li`)

This patch provides functions to support the now popular
[Element.querySelector](https://developer.mozilla.org/en-US/docs/Web/API/Element.querySelector) interface. Request for the same is also made
in the Github issue #227.

Also introducing access to document object through ffi, which is a
popular element on which .querySelector is applied.

---

Initial patch, will need improvements.
