### PR TITLE
Fix localeEncoding() in lib/rts.js

### DIFF
--- a/lib/rts.js
+++ b/lib/rts.js
@@ -264,11 +264,11 @@ function mMV(mv, f) {
 
 function localeEncoding() {
     var le = newByteArr(5);
-    le['b']['i8'] = 'U'.charCodeAt(0);
-    le['b']['i8'] = 'T'.charCodeAt(0);
-    le['b']['i8'] = 'F'.charCodeAt(0);
-    le['b']['i8'] = '-'.charCodeAt(0);
-    le['b']['i8'] = '8'.charCodeAt(0);
+    le['v']['i8'][0] = 'U'.charCodeAt(0);
+    le['v']['i8'][1] = 'T'.charCodeAt(0);
+    le['v']['i8'][2] = 'F'.charCodeAt(0);
+    le['v']['i8'][3] = '-'.charCodeAt(0);
+    le['v']['i8'][4] = '8'.charCodeAt(0);
     return le;
 }
 


### PR DESCRIPTION
I don't know how important localeEncoding() is, but it is apparently broken.
