### PR TITLE
add network-uri as a separate dependency

### DIFF
--- a/haste-compiler.cabal
+++ b/haste-compiler.cabal
@@ -62,6 +62,7 @@ Executable haste-boot
         bzlib,
         transformers,
         network,
+        network-uri,
         HTTP,
         shellmate >= 0.1.5,
         ghc-paths,


### PR DESCRIPTION
it looks like network-uri has been split off of the network package, so needs to be included as a separate dependency
see for details: https://hackage.haskell.org/package/network
