### PR TITLE
Ignore JS files, built for tests, in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.o
 *.jsmod
 dist/
+TestDriver.js
+TestDriver.O2.js


### PR DESCRIPTION
After a test run, this becomes a visible clutter in the project directory.
