### PR TITLE
Detect and run tests in sandbox if present

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -10,6 +10,13 @@ if [[ $JS == "" ]] ; then
     fi
 fi
 
+if [[ -f 'cabal.sandbox.config' ]]; then
+    CABAL_SANDBOX_PKG_CONF=$(ls -d .cabal-sandbox/*-packages.conf.d | tail -1)
+    CABAL_SANDBOX_ARGS="-no-user-package-db -package-db=$CABAL_SANDBOX_PKG_CONF"
+    SANDBOX_DIR=$(cat cabal.sandbox.config  | grep 'prefix:' | cut -d ':' -f 2)
+    echo "Notice: running with a sandbox located at:$SANDBOX_DIR" >&2
+fi
+
 runTest() {
     module=$1
     quiet=$2
@@ -18,7 +25,7 @@ runTest() {
     ghc_stderr_file=`mktemp`
     echo "Running test $module..."
 
-    ghc_output=`runghc -w -DTEST_MODULE=$module TestDriver.hs 2> $ghc_stderr_file`
+    ghc_output=`runghc $CABAL_SANDBOX_ARGS -w -DTEST_MODULE=$module TestDriver.hs 2> $ghc_stderr_file`
 
     if [[ $quiet == 1 ]] ; then
         $hastec --onexec -O0 -DTEST_MODULE=$module TestDriver.hs > /dev/null 2>&1


### PR DESCRIPTION
Instead of assuming a global install, use the sandbox to run tests when
available. Mimics behaviour of cabal install.

> I don't know what general tests status it but I only get 52/57 succeeded. Will try to look into individual tests as to what is wrong. Also I noticed that travis doesn't actually run, `runtests.sh`.
