### PR TITLE
The fun.js example was not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,14 +161,15 @@ them from JavaScript:
 fun.hs:
 
     import Haste.Foreign
+    import Haste.Prim (toJSStr)
     
     fun :: Int -> String -> IO String
     fun n s = return $ "The number is " ++ show n ++ " and the string is " ++ s
     
     main = do
-      export "fun" fun
+      export (toJSStr "fun") fun
 
-fun.js:
+legacy.js:
 
     function mymain() {
       console.log(Haste.fun(42, "hello"));
@@ -176,11 +177,11 @@ fun.js:
 
 ...then compile with:
 
-    $ hastec '--start=$HASTE_MAIN(); mymain();' --with-js=fun.js fun.hs
+    $ hastec '--start=$HASTE_MAIN(); mymain();' --with-js=legacy.js fun.hs
 
 `fun.hs` will export the function `fun` when its `main` function is run.
 Our JavaScript obviously needs to run after that, so we create our "real" main
-function in `fun.js`. Finally, we tell the compiler to start the program by
+function in `legacy.js`. Finally, we tell the compiler to start the program by
 first executing Haste's `main` function (the `$HASTE_MAIN` gets replaced by
 whatever name the compiler chooses for the Haste `main`) and then executing
 our own `mymain`.


### PR DESCRIPTION
The fun.js examples was not working by the 2 following reasons:
1. Did not compile with the following error:

fun.hs:7:10:
    Couldn't match type ‘[Char]’ with ‘GHC.Ptr.Ptr Haste.Prim.JSChr’
    Expected type: Haste.Prim.JSString
      Actual type: [Char]
    In the first argument of ‘export’, namely ‘"fun"’
    In a stmt of a 'do' block: export "fun" fun
    In the expression: do { export "fun" fun }
1. Compiler failed when trying to include "fun.js" while generating fun.js (the compiler line generates fun.js from fun.hs) with the following error:
   hastec: fun.js: openBinaryFile: resource busy (file is locked)

This fixes those two cases
