### PR TITLE
Add "wheel" event

### DIFF
--- a/lib/stdlib.js
+++ b/lib/stdlib.js
@@ -94,7 +94,18 @@ function jsSetCB(elem, evt, cb) {
     case 'keyup':
     case 'keydown':
         fun = function(x) {B(A(cb,[[0,x.keyCode],0]));};
-        break;        
+        break;
+    case 'wheel':
+        fun = function(x) {
+            var mpos = jsGetMouseCoords(x);
+            var mx = [0,mpos[0]];
+            var my = [0,mpos[1]];
+            var mdx = [0,x.deltaX];
+            var mdy = [0,x.deltaY];
+            var mdz = [0,x.deltaZ];
+            B(A(cb,[[0,mx,my],[0,mdx,mdy,mdz],0]));
+        };
+        break;
     default:
         fun = function() {B(A(cb,[0]));};
         break;

--- a/libraries/haste-lib/src/Haste/Callback.hs
+++ b/libraries/haste-lib/src/Haste/Callback.hs
@@ -89,6 +89,7 @@ data Event m a where
   OnKeyUp     :: Event m (Int -> m ())
   OnKeyDown   :: Event m (Int -> m ())
   OnSubmit    :: Event m (m ())
+  OnWheel     :: Event m ((Int, Int) -> (Double, Double, Double) -> m ())
 
 asEvtTypeOf :: Event m a -> a -> a
 asEvtTypeOf _ = id
@@ -119,6 +120,7 @@ evtName evt =
     OnFocus     -> "focus"
     OnBlur      -> "blur"
     OnSubmit    -> "submit"
+    OnWheel     -> "wheel"
 
 -- | Friendlier name for @setCallback@.
 onEvent :: MonadIO m => Elem -> Event IO a -> a -> m Bool


### PR DESCRIPTION
I only made the callback work on the position of the scroll wheel and the (delta_x, delta_y, delta_z) scroll values, which is probably not the entire set of things one might ever want to query from a mouse wheel event, but it is a start, at least.
