### PR TITLE
'use strict' inside the closure when namespaced

### DIFF
--- a/src/Haste/Linker.hs
+++ b/src/Haste/Linker.hs
@@ -39,9 +39,9 @@ link cfg pkgid target = do
     $ assembleProg (wrapProg cfg) extlibs rtslibs progText callMain launchApp
   where
     assembleProg True extlibs rtslibs progText callMain launchApp =
-      (if useStrict cfg then stringUtf8 "\"use strict\";\n" else mempty)
-      <> stringUtf8 (unlines extlibs)
+      stringUtf8 (unlines extlibs)
       <> stringUtf8 "var hasteMain = function() {"
+      <> (if useStrict cfg then stringUtf8 "\n\"use strict\";\n" else mempty)
       <> stringUtf8 (unlines rtslibs)
       <> progText
       <> callMain


### PR DESCRIPTION
Instead of having `use strict` globally (and possibly make the browser assume other non-strict scripts as strict), it is safer to place it under the namespace.

Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode