### PR TITLE
(=:) now has a higher precendence

### DIFF
--- a/libraries/haste-lib/src/Haste/DOM/JSString.hs
+++ b/libraries/haste-lib/src/Haste/DOM/JSString.hs
@@ -78,6 +78,7 @@ attr :: JSString -> AttrName
 attr = AttrName
 
 -- | Create an 'Attribute'.
+infixl 4 =:
 (=:) :: AttrName -> AttrValue -> Attribute
 (=:) = attribute
 


### PR DESCRIPTION
It's nice to write 
```haskell
set date ["className" =: "date",
          "innerText" =: monthName month ++ " " ++ show year]
```

instead of 
```haskell
set date ["className" =: "date",
          "innerText" =: (monthName month ++ " " ++ show year)]
```