### PR TITLE
unregisterHandler uses MonadIO, for consistency

### DIFF
--- a/libraries/haste-lib/src/Haste/Events/Core.hs
+++ b/libraries/haste-lib/src/Haste/Events/Core.hs
@@ -41,8 +41,8 @@ data HandlerInfo = HandlerInfo {
   }
 
 -- | Unregister an event handler.
-unregisterHandler :: HandlerInfo -> IO ()
-unregisterHandler (HandlerInfo ev el f) = unregEvt el ev f
+unregisterHandler :: MonadIO m => HandlerInfo -> m ()
+unregisterHandler (HandlerInfo ev el f) = liftIO $ unregEvt el ev f
 
 -- | Reference to the event currently being handled.
 {-# NOINLINE evtRef #-}


### PR DESCRIPTION
You can register a handler in any MonadEvent (all of which are MonadIO) but
previously you could only unregister in IO.