### PR TITLE
Derive Eq, Ord for AttrName

### DIFF
--- a/libraries/haste-lib/src/Haste/DOM/Core.hs
+++ b/libraries/haste-lib/src/Haste/DOM/Core.hs
@@ -94,6 +94,7 @@ data AttrName
   = PropName  !JSString
   | StyleName !JSString
   | AttrName  !JSString
+  deriving (Eq, Ord)
 
 instance IsString AttrName where
   fromString = PropName . fromString


### PR DESCRIPTION
These are nice to have. Allows us to use `AttrName` as a key in a map.