### PR TITLE
Add more bindings for Haste.Graphics.Canvas

### DIFF
--- a/libraries/haste-lib/src/Haste/Graphics/Canvas.hs
+++ b/libraries/haste-lib/src/Haste/Graphics/Canvas.hs
@@ -372,13 +372,13 @@ renderOnTop (Canvas ctx _) (Picture p) = liftIO $ p ctx
 -- | Draw a picture onto a canvas without first clearing it, with a specific composition method
 renderOnTopBy :: MonadIO m => Canvas -> Picture a -> CompositionOperation -> m a
 renderOnTopBy canvas pic composition = liftIO $ do
-    jsSetGlobalCompositeOperation $ translate composition
+    jsSetGlobalCompositeOperation $ translateComposition composition
     rst <- renderOnTop canvas pic
-    jsSetGlobalCompositeOperation $ translate Default
+    jsSetGlobalCompositeOperation $ translateComposition Default
     return rst
         where
-            translate :: CompositionOperation -> String
-            translate c = fromJust $ lookup c dict
+            translateComposition :: CompositionOperation -> String
+            translateComposition c = fromJust $ lookup c dict
 
             dict = [
                 (Default, "source-over"),
@@ -607,5 +607,5 @@ writePixel (Canvas ctx _) (x, y) (RGBA r g b a) = liftIO $ do
 -- | Modify a pixel
 modifyPixel :: MonadIO m => Canvas -> Point -> (Color -> Color) -> m ()
 modifyPixel c p f = liftIO $ do
-    color <- readPixel c p
-    writePixel c p $ f color
+    color' <- readPixel c p
+    writePixel c p $ f color'

--- a/libraries/haste-lib/src/Haste/Graphics/Canvas.hs
+++ b/libraries/haste-lib/src/Haste/Graphics/Canvas.hs
@@ -12,7 +12,7 @@ module Haste.Graphics.Canvas (
     getCanvasById, getCanvas, createCanvas,
 
     -- * Rendering and reading canvases
-    render, renderOnTop, buffer, toDataURL,
+    render, renderOnTop, buffer, toDataURL, clearRect,
 
     -- * Colors and opacity
     setStrokeColor, setFillColor, color, opacity,
@@ -78,6 +78,12 @@ jsPopState = ffi "(function(ctx){ctx.restore();})"
 
 jsResetCanvas :: Elem -> IO ()
 jsResetCanvas = ffi "(function(e){e.width = e.width;})"
+
+jsClearRect :: Ctx
+            -> Double -> Double
+            -> Double -> Double
+            -> IO ()
+jsClearRect = ffi "(function(ctx,x,y,width,height){ctx.clearRect(x,y,width,height);})"
 
 jsDrawImage :: Ctx -> Elem -> Double -> Double -> IO ()
 jsDrawImage = ffi "(function(ctx,i,x,y){ctx.drawImage(i,x,y);})"
@@ -301,6 +307,10 @@ render (Canvas ctx el) (Picture p) = liftIO $ do
 renderOnTop :: MonadIO m => Canvas -> Picture a -> m a
 renderOnTop (Canvas ctx _) (Picture p) = liftIO $ p ctx
 
+-- | Clear the rectangular area between the given two points.
+clearRect :: Point -> Point -> Picture ()
+clearRect (x1, y1) (x2, y2) = Picture $ \ctx -> jsClearRect ctx x1 y1 (x2-x1) (y2-y1)
+
 -- | Generate a data URL from the contents of a canvas.
 toDataURL :: MonadIO m => Canvas -> m URL
 toDataURL (Canvas _ el) = liftIO $ do
@@ -389,7 +399,7 @@ fill (Shape shape) = Picture $ \ctx -> do
   jsBeginPath ctx
   shape ctx
   jsFill ctx
-  
+
 -- | Draw the contours of a shape.
 stroke :: Shape () -> Picture ()
 stroke (Shape shape) = Picture $ \ctx -> do

--- a/libraries/haste-lib/src/Haste/Graphics/Canvas.hs
+++ b/libraries/haste-lib/src/Haste/Graphics/Canvas.hs
@@ -21,7 +21,7 @@ module Haste.Graphics.Canvas (
     translate, scale, rotate,
     -- * Drawing shapes
     stroke, fill, clip,
-    lineWidth, line, path, rect, circle, arc,
+    lineWidth, line, path, rect, circle, arc, quadraticCurve, bezierCurve,
 
     -- * Rendering text
     font, text,
@@ -113,6 +113,19 @@ jsArc :: Ctx -> Double -> Double
              -> IO ()
 jsArc = ffi "(function(ctx, x, y, radius, fromAngle, toAngle){\
 ctx.arc(x, y, radius, fromAngle, toAngle);})"
+
+jsQuadraticCurve :: Ctx
+                 -> Double -> Double
+                 -> Double -> Double
+                 -> IO ()
+jsQuadraticCurve = ffi "(function(ctx,cx,cy,x,y){ctx.quadraticCurveTo(cx,cy,x,y);})"
+
+jsBezierCurve :: Ctx
+                 -> Double -> Double
+                 -> Double -> Double
+                 -> Double -> Double
+                 -> IO ()
+jsBezierCurve = ffi "(function(ctx,c1x,c1y,c2x,c2y,x,y){ctx.bezierCurveTo(c1x,c1y,c2x,c2y,x,y);})"
 
 jsCanvasToDataURL :: Elem -> IO JSString
 jsCanvasToDataURL = ffi "(function(e){return e.toDataURL('image/png');})"
@@ -450,6 +463,27 @@ twoPi = 2*pi
 --   (0, 0), with a radius of 10 pixels.
 arc :: Point -> Double -> Angle -> Angle -> Shape ()
 arc (x, y) radius from to = Shape $ \ctx -> jsArc ctx x y radius from to
+
+-- | Draw a quadratic Bezier curve.
+quadraticCurve ::
+    Point -- ^ Start point.
+    -> Point -- ^ End point.
+    -> Point -- ^ Control point.
+    -> Shape
+quadraticCurve (sx, sy) (ex, ey) (cx, cy) = Shape $ \ctx -> do
+    jsMoveTo ctx sx sy
+    jsQuadraticCurve cx cy ex ey
+
+-- | Draw a Bezier curve.
+bezierCurve ::
+    Point -- ^ Start point.
+    -> Point -- ^ End point.
+    -> Point -- ^ Start control point.
+    -> Point -- ^ End control point.
+    -> Shape
+bezierCurve (sx, sy) (ex, ey) (scx, scy) (ecx, ecy) = Shape $ \ctx -> do
+    jsMoveTo ctx sx sy
+    jsBezierCurve scx scy ecx ecy ex ey
 
 -- | Draw a picture using a certain font. Obviously only affects text.
 font :: String -> Picture () -> Picture ()


### PR DESCRIPTION
`clearRect`
`quadraticCurve`
`bezierCurve`
`renderOnTopBy` (to support different composition stratergies)
`readPixel`
`writePixel`
`modifyPixel`