### PR TITLE
Improved the error output for (.:)

### DIFF
--- a/libraries/haste-lib/src/Haste/Serialize.hs
+++ b/libraries/haste-lib/src/Haste/Serialize.hs
@@ -165,7 +165,7 @@ instance Applicative Parser where
 Dict o .: key =
   case lookup key o of
     Just x -> parseJSON x
-    _      -> Parser $ Left "Key not found"
+    _      -> Parser . Left $ "Key not found: " ++ fromJSStr key
 _ .: _ =
   Parser $ Left "Tried to do lookup on non-object!"
 


### PR DESCRIPTION
The error message now includes which key it was unable to find
in the JSON object.

This makes it a bit nicer to debug serialization code.