### PR TITLE
Added utility functions to Haste.Foreign

### DIFF
--- a/libraries/haste-lib/src/Haste/Foreign.hs
+++ b/libraries/haste-lib/src/Haste/Foreign.hs
@@ -5,6 +5,7 @@ module Haste.Foreign (
     ToAny (..), FromAny (..), JSAny,
     Opaque, toOpaque, fromOpaque,
     nullValue, toObject, has, get, index,
+    getMaybe, hasAll, lookupAny
 
     -- * Importing and exporting JavaScript functions
     FFI, JSFunc,
@@ -14,3 +15,34 @@ module Haste.Foreign (
 #endif
   ) where
 import Haste.Prim.Foreign
+import Haste.Prim (JSString)
+import Control.Monad (foldM)
+
+-- | Read a member from a JS object. Succeeds if the member exists.
+getMaybe :: (FromAny a) => JSAny -> JSString -> IO (Maybe a)
+getMaybe a k = do exists <- has a k
+                  if exists then Just <$> get a k
+                    else pure Nothing
+
+-- | Checks if a JS object has a list of members. Succeeds if the JS object
+--   has every member given in the list. 
+hasAll :: JSAny -> [JSString] -> IO Bool
+hasAll a ks = and <$> mapM (has a) ks
+
+
+-- | Looks up an object by a `.`-separated string. Succeeds if the lowest
+--   member exists.
+--
+-- Usage example:
+-- 
+-- >>> {'child': {'childrer': {'childerest': "I am very much a child."}}}
+--
+-- Given the JS Object above, we can access the deeply nested object,
+--  childerest, by lookupAny as in the below example
+--
+-- >>> lookupAny jsObject "child.childrer.childerest"
+lookupAny :: JSAny -> JSString -> IO (Maybe JSAny)
+lookupAny root i = foldM hasGet (Just root) $ J.match (J.regex "[^.]+" "g") i
+  where hasGet (Just parent) id = do h <- has parent id
+                                     if h then Just <$> get parent id
+                                       else pure Nothing

--- a/libraries/haste-lib/src/Haste/Foreign.hs
+++ b/libraries/haste-lib/src/Haste/Foreign.hs
@@ -43,6 +43,7 @@ hasAll a ks = and <$> mapM (has a) ks
 -- >>> lookupAny jsObject "child.childrer.childerest"
 lookupAny :: JSAny -> JSString -> IO (Maybe JSAny)
 lookupAny root i = foldM hasGet (Just root) $ J.match (J.regex "[^.]+" "g") i
-  where hasGet (Just parent) id = do h <- has parent id
+  where hasGet Nothing          = pure Nothing
+        hasGet (Just parent) id = do h <- has parent id
                                      if h then Just <$> get parent id
                                        else pure Nothing


### PR DESCRIPTION
getMaybe - get, but will return Nothing if the
member of the object doesn't exist

hasAll - a has that checks if several members exists

lookupAny - checks if a member exists by deep id, instead of
just a direct child to the object.