### PR TITLE
Relax upper bound on cryptonite version

### DIFF
--- a/haste-compiler.cabal
+++ b/haste-compiler.cabal
@@ -124,7 +124,7 @@ Executable hastec
         either,
         filepath,
         directory,
-        cryptonite >= 0.10 && < 0.20,
+        cryptonite >= 0.10 && < 1.0,
         ghc-simple >= 0.3 && < 0.4
     Main-Is:
         hastec.hs


### PR DESCRIPTION
lts-6.31 comes with cryptonite-0.21, which works just fine with haste-compiler.

From what I can see most of the recent cryptonite releases don't break backwards compatibility, so I figured the version dependency could be upped to the next major version. (Optimistically hoping that they do perform a major version bump on compat breakage)

This is the last change needed to make haste-compiler work on lts-6.31. I can provide an updated stack.yaml file to reflect this if you're interested.