### PR TITLE
Pin `either` to version that still has Control.Monad.Trans.Either.

### DIFF
--- a/haste-compiler.cabal
+++ b/haste-compiler.cabal
@@ -121,7 +121,7 @@ Executable hastec
         random,
         system-fileio,
         shellmate >= 0.3.2.2 && <0.4,
-        either,
+        either >= 4.4 && <5,
         filepath,
         directory,
         cryptonite >= 0.10 && < 1.0,


### PR DESCRIPTION
Hello,

I tried to build `haste` today (from git) using the instructions in the README, and encountered this error:

```
Preprocessing executable 'hastec' for haste-compiler-0.6.0.0...

src/Haste/Linker.hs:9:8:
    Could not find module ‘Control.Monad.Trans.Either’
    Perhaps you meant
      Control.Monad.Trans.Writer (needs flag -package-key transformers-0.4.2.0@trans_GZTjP9K5WFq01xC9BAGQpF)
      Control.Monad.Trans.Error (needs flag -package-key transformers-0.4.2.0@trans_GZTjP9K5WFq01xC9BAGQpF)
      Control.Monad.Trans.Reader (needs flag -package-key transformers-0.4.2.0@trans_GZTjP9K5WFq01xC9BAGQpF)
    Use -v to see a list of the files searched for.
```

It seems that the latest version of `either` has dropped `Control.Monad.Trans.Either`:

https://github.com/ekmett/either/commit/543f78bce4bcd8131318b912574d409f59ce6144

So, this PR holds back the version of `either` to a version where `Control.Monad.Trans.Either` still exists.  This permits `haste` to build for me.  (There are some failing tests but they're probably unrelated.)

The other option would be to migrate to `Control.Monad.Trans.Except` from `transformers`, or `transformers-compat` as suggested by the CHANGELOG message in the above commit, but I do not feel qualified to make that change (at least not at the moment).